### PR TITLE
Configured for Scala 2.11 as Play 2.5 does not support Scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
 language: scala
 
 scala:
-  - 2.10.5
-#  - 2.11.8
+  - 2.11.8
 branches:
   only:
     - master
@@ -30,12 +29,12 @@ jdk:
 script:
   - sbt -jvm-opts travis/jvmopts clean
   - sbt -jvm-opts travis/jvmopts '++ 2.11.8 api/compile'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 common/compile' '++ 2.10.5 common/publishLocal'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 swaggerModel/compile' '++ 2.10.5 swaggerModel/publishLocal'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 apiFirstCore/compile' '++ 2.10.5 apiFirstCore/publishLocal'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 swaggerParser/compile' '++ 2.10.5 swaggerParser/publishLocal'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 playScalaGenerator/compile' '++ 2.10.5 playScalaGenerator/publishLocal'
-  - sbt -jvm-opts travis/jvmopts '++ 2.10.5 plugin/compile' '++ 2.10.5 plugin/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 common/compile' '++ 2.11.8 common/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 swaggerModel/compile' '++ 2.11.8 swaggerModel/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 apiFirstCore/compile' '++ 2.11.8 apiFirstCore/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 swaggerParser/compile' '++ 2.11.8 swaggerParser/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 playScalaGenerator/compile' '++ 2.11.8 playScalaGenerator/publishLocal'
+  - sbt -jvm-opts travis/jvmopts '++ 2.11.8 plugin/compile' '++ 2.11.8 plugin/publishLocal'
 #  - sbt -jvm-opts travis/jvmopts clean compile
   - sbt -jvm-opts travis/jvmopts test
   - sbt -jvm-opts travis/jvmopts_scripted scripted

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import bintray.Keys._
 import sbt._
 
 val PlayVersion = "2.5.4"
-val Scala10 = "2.10.5"
 val Scala11 = "2.11.8"
 val ProjectVersion = "0.1.17"
 
@@ -13,7 +12,7 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 lazy val common = (project in file("common"))
   .settings(commonSettings: _*)
   .settings(
-    scalaVersion := Scala10,
+    scalaVersion := Scala11,
     name := "api-first-hand-common",
     libraryDependencies ++= deps.jacksonsJava ++ deps.test
   )
@@ -32,15 +31,14 @@ lazy val swaggerModel = (project in file("swagger-model"))
   .settings(commonSettings: _*)
   .settings(
     name := "swagger-model",
-    scalaVersion := Scala10,
-    crossScalaVersions := Seq(Scala10, Scala11),
+    scalaVersion := Scala11,
     libraryDependencies ++= deps.swaggerModel ++ deps.test
   )
 
 lazy val apiFirstCore = (project in file("api-first-core"))
   .settings(commonSettings: _*)
   .settings(
-    scalaVersion := Scala10,
+    scalaVersion := Scala11,
     name := "api-first-core",
     libraryDependencies ++= deps.test
   )
@@ -48,7 +46,7 @@ lazy val apiFirstCore = (project in file("api-first-core"))
 lazy val swaggerParser = (project in file("swagger-parser"))
   .settings(commonSettings: _*)
   .settings(
-    scalaVersion := Scala10,
+    scalaVersion := Scala11,
     name := "swagger-parser",
     libraryDependencies ++= deps.swaggerParser(scalaVersion.value) ++ deps.test
   )
@@ -57,7 +55,7 @@ lazy val swaggerParser = (project in file("swagger-parser"))
 lazy val playScalaGenerator = (project in file("play-scala-generator"))
   .settings(commonSettings: _*)
   .settings(
-    scalaVersion := Scala10,
+    scalaVersion := Scala11,
     name := "play-scala-generator",
     libraryDependencies ++= deps.playScalaGenerator ++ deps.test
   )


### PR DESCRIPTION
As the project explicitly states Play 2.5.4+ compatibility, cross compiling to 2.10 is not possible as it has been [dropped by Play itself](https://www.playframework.com/documentation/2.5.x/Migration25#Scala-2.10-support-discontinued).
