### PR TITLE
Make generated controllers follow scalariform rules

### DIFF
--- a/play-scala-generator/src/main/scala/de/zalando/apifirst/generators/controllersStep.scala
+++ b/play-scala-generator/src/main/scala/de/zalando/apifirst/generators/controllersStep.scala
@@ -202,9 +202,9 @@ object PlayScalaControllerAnalyzer {
   case class UnmanagedPart(marker: ApiCall, relevantCode: Seq[String])
 
   val controllerImports = Seq(
-    "play.api.mvc.{Action, Controller}",
+    "play.api.mvc.{ Action, Controller }",
     "play.api.data.validation.Constraint",
-    "play.api.inject.{ApplicationLifecycle,ConfigurationProvider}",
+    "play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }",
     "de.zalando.play.controllers._",
     "PlayBodyParsing._",
     "PlayValidations._",

--- a/play-scala-generator/src/test/resources/expected_results/controllers/all_of_imports_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/all_of_imports_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package all_of_imports.yaml {
         // ----- Start of unmanaged code area for constructor All_of_importsYaml
 
         // ----- End of unmanaged code area for constructor All_of_importsYaml
-        val post = postAction { (body: DatetimeValue) =>  
+        val post = postAction { (body: DatetimeValue) =>
             // ----- Start of unmanaged code area for action  All_of_importsYaml.post
             NotImplementedYet
             // ----- End of unmanaged code area for action  All_of_importsYaml.post
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/basic_auth_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/basic_auth_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package basic.auth.api.yaml {
         // ----- Start of unmanaged code area for constructor BasicAuthApiYaml
 
         // ----- End of unmanaged code area for constructor BasicAuthApiYaml
-        val get = getAction {  _ =>  
+        val get = getAction {  _ =>
             // ----- Start of unmanaged code area for action  BasicAuthApiYaml.get
             NotImplementedYet
             // ----- End of unmanaged code area for action  BasicAuthApiYaml.get
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/basic_polymorphism_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/basic_polymorphism_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package basic_polymorphism.yaml {
         // ----- Start of unmanaged code area for constructor Basic_polymorphismYaml
 
         // ----- End of unmanaged code area for constructor Basic_polymorphismYaml
-        val put = putAction { (dummy: PutDummy) =>  
+        val put = putAction { (dummy: PutDummy) =>
             // ----- Start of unmanaged code area for action  Basic_polymorphismYaml.put
             NotImplementedYet
             // ----- End of unmanaged code area for action  Basic_polymorphismYaml.put
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/cross_spec_references_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/cross_spec_references_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package cross_spec_references.yaml {
         // ----- Start of unmanaged code area for constructor Cross_spec_referencesYaml
 
         // ----- End of unmanaged code area for constructor Cross_spec_referencesYaml
-        val post = postAction { (root: ModelSchemaRoot) =>  
+        val post = postAction { (root: ModelSchemaRoot) =>
             // ----- Start of unmanaged code area for action  Cross_spec_referencesYaml.post
             NotImplementedYet
             // ----- End of unmanaged code area for action  Cross_spec_referencesYaml.post
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/echo_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/echo_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,12 +33,12 @@ package echo {
         // ----- Start of unmanaged code area for constructor EchoHandler
 
         // ----- End of unmanaged code area for constructor EchoHandler
-        val method = methodAction {  _ =>  
+        val method = methodAction {  _ =>
             // ----- Start of unmanaged code area for action  EchoHandler.method
             NotImplementedYet
             // ----- End of unmanaged code area for action  EchoHandler.method
         }
-    
+
     }
 }
 package echo {
@@ -59,11 +59,11 @@ package echo {
             NotImplementedYet
             // ----- End of unmanaged code area for action  EchoApiYaml.post
         }
-        val gettest_pathById = gettest_pathByIdAction { (id: String) =>  
+        val gettest_pathById = gettest_pathByIdAction { (id: String) =>
             // ----- Start of unmanaged code area for action  EchoApiYaml.gettest_pathById
             NotImplementedYet
             // ----- End of unmanaged code area for action  EchoApiYaml.gettest_pathById
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/error_in_array_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/error_in_array_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package error_in_array.yaml {
         // ----- Start of unmanaged code area for constructor Error_in_arrayYaml
 
         // ----- End of unmanaged code area for constructor Error_in_arrayYaml
-        val getschemaModel = getschemaModelAction { (root: ModelSchemaRoot) =>  
+        val getschemaModel = getschemaModelAction { (root: ModelSchemaRoot) =>
             // ----- Start of unmanaged code area for action  Error_in_arrayYaml.getschemaModel
             NotImplementedYet
             // ----- End of unmanaged code area for action  Error_in_arrayYaml.getschemaModel
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/expanded_polymorphism_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/expanded_polymorphism_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -39,16 +39,16 @@ package expanded {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Expanded_polymorphismYaml.findPets
         }
-        val addPet = addPetAction { (pet: NewPet) =>  
+        val addPet = addPetAction { (pet: NewPet) =>
             // ----- Start of unmanaged code area for action  Expanded_polymorphismYaml.addPet
             NotImplementedYet
             // ----- End of unmanaged code area for action  Expanded_polymorphismYaml.addPet
         }
-        val deletePet = deletePetAction { (id: Long) =>  
+        val deletePet = deletePetAction { (id: Long) =>
             // ----- Start of unmanaged code area for action  Expanded_polymorphismYaml.deletePet
             NotImplementedYet
             // ----- End of unmanaged code area for action  Expanded_polymorphismYaml.deletePet
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/form_data_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/form_data_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -53,6 +53,6 @@ package form_data.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Form_dataYaml.postboth
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/full_petstore_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/full_petstore_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,27 +33,27 @@ package full.petstore.api.yaml {
         // ----- Start of unmanaged code area for constructor FullPetstoreApiYaml
 
         // ----- End of unmanaged code area for constructor FullPetstoreApiYaml
-        val findPetsByTags = findPetsByTagsAction { (tags: PetsFindByStatusGetStatus) =>  
+        val findPetsByTags = findPetsByTagsAction { (tags: PetsFindByStatusGetStatus) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.findPetsByTags
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.findPetsByTags
         }
-        val placeOrder = placeOrderAction { (body: StoresOrderPostBody) =>  
+        val placeOrder = placeOrderAction { (body: StoresOrderPostBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.placeOrder
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.placeOrder
         }
-        val createUser = createUserAction { (body: UsersUsernamePutBody) =>  
+        val createUser = createUserAction { (body: UsersUsernamePutBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.createUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.createUser
         }
-        val createUsersWithListInput = createUsersWithListInputAction { (body: UsersCreateWithListPostBody) =>  
+        val createUsersWithListInput = createUsersWithListInputAction { (body: UsersCreateWithListPostBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.createUsersWithListInput
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.createUsersWithListInput
         }
-        val getUserByName = getUserByNameAction { (username: String) =>  
+        val getUserByName = getUserByNameAction { (username: String) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.getUserByName
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.getUserByName
@@ -64,42 +64,42 @@ package full.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.updateUser
         }
-        val deleteUser = deleteUserAction { (username: String) =>  
+        val deleteUser = deleteUserAction { (username: String) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.deleteUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.deleteUser
         }
-        val updatePet = updatePetAction { (body: PetsPostBody) =>  
+        val updatePet = updatePetAction { (body: PetsPostBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.updatePet
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.updatePet
         }
-        val addPet = addPetAction { (body: PetsPostBody) =>  
+        val addPet = addPetAction { (body: PetsPostBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.addPet
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.addPet
         }
-        val createUsersWithArrayInput = createUsersWithArrayInputAction { (body: UsersCreateWithListPostBody) =>  
+        val createUsersWithArrayInput = createUsersWithArrayInputAction { (body: UsersCreateWithListPostBody) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.createUsersWithArrayInput
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.createUsersWithArrayInput
         }
-        val getOrderById = getOrderByIdAction { (orderId: String) =>  
+        val getOrderById = getOrderByIdAction { (orderId: String) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.getOrderById
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.getOrderById
         }
-        val deleteOrder = deleteOrderAction { (orderId: String) =>  
+        val deleteOrder = deleteOrderAction { (orderId: String) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.deleteOrder
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.deleteOrder
         }
-        val logoutUser = logoutUserAction {  _ =>  
+        val logoutUser = logoutUserAction {  _ =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.logoutUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.logoutUser
         }
-        val getPetById = getPetByIdAction { (petId: Long) =>  
+        val getPetById = getPetByIdAction { (petId: Long) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.getPetById
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.getPetById
@@ -116,7 +116,7 @@ package full.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.deletePet
         }
-        val findPetsByStatus = findPetsByStatusAction { (status: PetsFindByStatusGetStatus) =>  
+        val findPetsByStatus = findPetsByStatusAction { (status: PetsFindByStatusGetStatus) =>
             // ----- Start of unmanaged code area for action  FullPetstoreApiYaml.findPetsByStatus
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.findPetsByStatus
@@ -127,6 +127,6 @@ package full.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  FullPetstoreApiYaml.loginUser
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/hackweek_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/hackweek_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package hackweek.yaml {
         // ----- Start of unmanaged code area for constructor HackweekYaml
 
         // ----- End of unmanaged code area for constructor HackweekYaml
-        val getschemaModel = getschemaModelAction { (root: ModelSchemaRoot) =>  
+        val getschemaModel = getschemaModelAction { (root: ModelSchemaRoot) =>
             // ----- Start of unmanaged code area for action  HackweekYaml.getschemaModel
             NotImplementedYet
             // ----- End of unmanaged code area for action  HackweekYaml.getschemaModel
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/heroku_petstore_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/heroku_petstore_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -35,26 +35,26 @@ package heroku.petstore.api.yaml {
         // ----- Start of unmanaged code area for constructor HerokuPetstoreApiYaml
 
         // ----- End of unmanaged code area for constructor HerokuPetstoreApiYaml
-        val get = getAction { (limit: BigInt) =>  
+        val get = getAction { (limit: BigInt) =>
             // ----- Start of unmanaged code area for action  HerokuPetstoreApiYaml.get
             NotImplementedYet
             // ----- End of unmanaged code area for action  HerokuPetstoreApiYaml.get
         }
-        val put = putAction { (pet: PutPet) =>  
+        val put = putAction { (pet: PutPet) =>
             // ----- Start of unmanaged code area for action  HerokuPetstoreApiYaml.put
             NotImplementedYet
             // ----- End of unmanaged code area for action  HerokuPetstoreApiYaml.put
         }
-        val post = postAction { (pet: Pet) =>  
+        val post = postAction { (pet: Pet) =>
             // ----- Start of unmanaged code area for action  HerokuPetstoreApiYaml.post
             NotImplementedYet
             // ----- End of unmanaged code area for action  HerokuPetstoreApiYaml.post
         }
-        val getbyPetId = getbyPetIdAction { (petId: String) =>  
+        val getbyPetId = getbyPetIdAction { (petId: String) =>
             // ----- Start of unmanaged code area for action  HerokuPetstoreApiYaml.getbyPetId
             NotImplementedYet
             // ----- End of unmanaged code area for action  HerokuPetstoreApiYaml.getbyPetId
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/i038_invalid_enum_members_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/i038_invalid_enum_members_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package i038_invalid_enum_members.yaml {
         // ----- Start of unmanaged code area for constructor I038_invalid_enum_membersYaml
 
         // ----- End of unmanaged code area for constructor I038_invalid_enum_membersYaml
-        val get = getAction {  _ =>  
+        val get = getAction {  _ =>
             // ----- Start of unmanaged code area for action  I038_invalid_enum_membersYaml.get
             NotImplementedYet
             // ----- End of unmanaged code area for action  I038_invalid_enum_membersYaml.get
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/instagram_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/instagram_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -39,27 +39,27 @@ package instagram.api.yaml {
         // ----- Start of unmanaged code area for constructor InstagramApiYaml
 
         // ----- End of unmanaged code area for constructor InstagramApiYaml
-        val getmediaByMedia_idLikes = getmediaByMedia_idLikesAction { (media_id: BigInt) =>  
+        val getmediaByMedia_idLikes = getmediaByMedia_idLikesAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_idLikes
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_idLikes
         }
-        val postmediaByMedia_idLikes = postmediaByMedia_idLikesAction { (media_id: BigInt) =>  
+        val postmediaByMedia_idLikes = postmediaByMedia_idLikesAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.postmediaByMedia_idLikes
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.postmediaByMedia_idLikes
         }
-        val deletemediaByMedia_idLikes = deletemediaByMedia_idLikesAction { (media_id: BigInt) =>  
+        val deletemediaByMedia_idLikes = deletemediaByMedia_idLikesAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.deletemediaByMedia_idLikes
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.deletemediaByMedia_idLikes
         }
-        val getusersByUser_idFollows = getusersByUser_idFollowsAction { (user_id: BigDecimal) =>  
+        val getusersByUser_idFollows = getusersByUser_idFollowsAction { (user_id: BigDecimal) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getusersByUser_idFollows
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersByUser_idFollows
         }
-        val getlocationsByLocation_id = getlocationsByLocation_idAction { (location_id: BigInt) =>  
+        val getlocationsByLocation_id = getlocationsByLocation_idAction { (location_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getlocationsByLocation_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getlocationsByLocation_id
@@ -76,22 +76,22 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersSelfMediaLiked
         }
-        val gettagsByTag_name = gettagsByTag_nameAction { (tag_name: String) =>  
+        val gettagsByTag_name = gettagsByTag_nameAction { (tag_name: String) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.gettagsByTag_name
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.gettagsByTag_name
         }
-        val gettagsSearch = gettagsSearchAction { (q: MediaFilter) =>  
+        val gettagsSearch = gettagsSearchAction { (q: MediaFilter) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.gettagsSearch
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.gettagsSearch
         }
-        val getusersByUser_idFollowed_by = getusersByUser_idFollowed_byAction { (user_id: BigDecimal) =>  
+        val getusersByUser_idFollowed_by = getusersByUser_idFollowed_byAction { (user_id: BigDecimal) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getusersByUser_idFollowed_by
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersByUser_idFollowed_by
         }
-        val getmediaByMedia_idComments = getmediaByMedia_idCommentsAction { (media_id: BigInt) =>  
+        val getmediaByMedia_idComments = getmediaByMedia_idCommentsAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_idComments
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_idComments
@@ -102,12 +102,12 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.postmediaByMedia_idComments
         }
-        val deletemediaByMedia_idComments = deletemediaByMedia_idCommentsAction { (media_id: BigInt) =>  
+        val deletemediaByMedia_idComments = deletemediaByMedia_idCommentsAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.deletemediaByMedia_idComments
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.deletemediaByMedia_idComments
         }
-        val gettagsByTag_nameMediaRecent = gettagsByTag_nameMediaRecentAction { (tag_name: String) =>  
+        val gettagsByTag_nameMediaRecent = gettagsByTag_nameMediaRecentAction { (tag_name: String) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.gettagsByTag_nameMediaRecent
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.gettagsByTag_nameMediaRecent
@@ -124,7 +124,7 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersSelfFeed
         }
-        val getusersByUser_id = getusersByUser_idAction { (user_id: BigDecimal) =>  
+        val getusersByUser_id = getusersByUser_idAction { (user_id: BigDecimal) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getusersByUser_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersByUser_id
@@ -141,7 +141,7 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getgeographiesByGeo_idMediaRecent
         }
-        val getmediaByShortcode = getmediaByShortcodeAction { (shortcode: String) =>  
+        val getmediaByShortcode = getmediaByShortcodeAction { (shortcode: String) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getmediaByShortcode
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getmediaByShortcode
@@ -152,12 +152,12 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getlocationsSearch
         }
-        val getusersSelfRequested_by = getusersSelfRequested_byAction {  _ =>  
+        val getusersSelfRequested_by = getusersSelfRequested_byAction {  _ =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getusersSelfRequested_by
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersSelfRequested_by
         }
-        val getmediaByMedia_id = getmediaByMedia_idAction { (media_id: BigInt) =>  
+        val getmediaByMedia_id = getmediaByMedia_idAction { (media_id: BigInt) =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getmediaByMedia_id
@@ -174,11 +174,11 @@ package instagram.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getusersByUser_idMediaRecent
         }
-        val getmediaPopular = getmediaPopularAction {  _ =>  
+        val getmediaPopular = getmediaPopularAction {  _ =>
             // ----- Start of unmanaged code area for action  InstagramApiYaml.getmediaPopular
             NotImplementedYet
             // ----- End of unmanaged code area for action  InstagramApiYaml.getmediaPopular
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/minimal_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/minimal_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package admin {
         // ----- Start of unmanaged code area for constructor Dashboard
 
         // ----- End of unmanaged code area for constructor Dashboard
-        val index = indexAction {  _ =>  
+        val index = indexAction {  _ =>
             // ----- Start of unmanaged code area for action  Dashboard.index
             NotImplementedYet
             // ----- End of unmanaged code area for action  Dashboard.index
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/nakadi_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/nakadi_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,7 +33,7 @@ package nakadi.yaml {
         // ----- Start of unmanaged code area for constructor NakadiYaml
 
         // ----- End of unmanaged code area for constructor NakadiYaml
-        val nakadiHackGet_metrics = nakadiHackGet_metricsAction {  _ =>  
+        val nakadiHackGet_metrics = nakadiHackGet_metricsAction {  _ =>
             // ----- Start of unmanaged code area for action  NakadiYaml.nakadiHackGet_metrics
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackGet_metrics
@@ -50,7 +50,7 @@ package nakadi.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackGet_partition
         }
-        val nakadiHackGet_topics = nakadiHackGet_topicsAction {  _ =>  
+        val nakadiHackGet_topics = nakadiHackGet_topicsAction {  _ =>
             // ----- Start of unmanaged code area for action  NakadiYaml.nakadiHackGet_topics
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackGet_topics
@@ -67,7 +67,7 @@ package nakadi.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackPost_event
         }
-        val nakadiHackGet_partitions = nakadiHackGet_partitionsAction { (topic: String) =>  
+        val nakadiHackGet_partitions = nakadiHackGet_partitionsAction { (topic: String) =>
             // ----- Start of unmanaged code area for action  NakadiYaml.nakadiHackGet_partitions
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackGet_partitions
@@ -78,6 +78,6 @@ package nakadi.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  NakadiYaml.nakadiHackPost_events
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/security_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/security_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,11 +33,11 @@ package security.api.yaml {
         // ----- Start of unmanaged code area for constructor SecurityApiYaml
 
         // ----- End of unmanaged code area for constructor SecurityApiYaml
-        val getPetsById = getPetsByIdAction { (id: PetsIdGetId) =>  
+        val getPetsById = getPetsByIdAction { (id: PetsIdGetId) =>
             // ----- Start of unmanaged code area for action  SecurityApiYaml.getPetsById
             NotImplementedYet
             // ----- End of unmanaged code area for action  SecurityApiYaml.getPetsById
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/simple_petstore_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/simple_petstore_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,12 +33,12 @@ package simple_petstore_api_yaml {
         // ----- Start of unmanaged code area for constructor SimplePetstoreApiYaml
 
         // ----- End of unmanaged code area for constructor SimplePetstoreApiYaml
-        val addPet = addPetAction { (pet: NewPet) =>  
+        val addPet = addPetAction { (pet: NewPet) =>
             // ----- Start of unmanaged code area for action  SimplePetstoreApiYaml.addPet
             NotImplementedYet
             // ----- End of unmanaged code area for action  SimplePetstoreApiYaml.addPet
         }
-    
+
     }
 }
 package simple_petstore_api_yaml {
@@ -59,16 +59,16 @@ package simple_petstore_api_yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Dashboard.methodLevel
         }
-        val pathLevelGet = pathLevelGetAction { (id: Long) =>  
+        val pathLevelGet = pathLevelGetAction { (id: Long) =>
             // ----- Start of unmanaged code area for action  Dashboard.pathLevelGet
             NotImplementedYet
             // ----- End of unmanaged code area for action  Dashboard.pathLevelGet
         }
-        val pathLevelDelete = pathLevelDeleteAction { (id: Long) =>  
+        val pathLevelDelete = pathLevelDeleteAction { (id: Long) =>
             // ----- Start of unmanaged code area for action  Dashboard.pathLevelDelete
             NotImplementedYet
             // ----- End of unmanaged code area for action  Dashboard.pathLevelDelete
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/split_petstore_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/split_petstore_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,27 +33,27 @@ package split.petstore.api.yaml {
         // ----- Start of unmanaged code area for constructor SplitPetstoreApiYaml
 
         // ----- End of unmanaged code area for constructor SplitPetstoreApiYaml
-        val findPetsByTags = findPetsByTagsAction { (tags: PetsFindByStatusGetStatus) =>  
+        val findPetsByTags = findPetsByTagsAction { (tags: PetsFindByStatusGetStatus) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.findPetsByTags
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.findPetsByTags
         }
-        val placeOrder = placeOrderAction { (body: StoresOrderPostBody) =>  
+        val placeOrder = placeOrderAction { (body: StoresOrderPostBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.placeOrder
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.placeOrder
         }
-        val createUser = createUserAction { (body: UsersUsernamePutBody) =>  
+        val createUser = createUserAction { (body: UsersUsernamePutBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.createUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.createUser
         }
-        val createUsersWithListInput = createUsersWithListInputAction { (body: UsersCreateWithListPostBody) =>  
+        val createUsersWithListInput = createUsersWithListInputAction { (body: UsersCreateWithListPostBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.createUsersWithListInput
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.createUsersWithListInput
         }
-        val getUserByName = getUserByNameAction { (username: String) =>  
+        val getUserByName = getUserByNameAction { (username: String) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.getUserByName
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.getUserByName
@@ -64,42 +64,42 @@ package split.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.updateUser
         }
-        val deleteUser = deleteUserAction { (username: String) =>  
+        val deleteUser = deleteUserAction { (username: String) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.deleteUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.deleteUser
         }
-        val updatePet = updatePetAction { (body: PetsPostBody) =>  
+        val updatePet = updatePetAction { (body: PetsPostBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.updatePet
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.updatePet
         }
-        val addPet = addPetAction { (body: PetsPostBody) =>  
+        val addPet = addPetAction { (body: PetsPostBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.addPet
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.addPet
         }
-        val createUsersWithArrayInput = createUsersWithArrayInputAction { (body: UsersCreateWithListPostBody) =>  
+        val createUsersWithArrayInput = createUsersWithArrayInputAction { (body: UsersCreateWithListPostBody) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.createUsersWithArrayInput
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.createUsersWithArrayInput
         }
-        val getOrderById = getOrderByIdAction { (orderId: String) =>  
+        val getOrderById = getOrderByIdAction { (orderId: String) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.getOrderById
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.getOrderById
         }
-        val deleteOrder = deleteOrderAction { (orderId: String) =>  
+        val deleteOrder = deleteOrderAction { (orderId: String) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.deleteOrder
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.deleteOrder
         }
-        val logoutUser = logoutUserAction {  _ =>  
+        val logoutUser = logoutUserAction {  _ =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.logoutUser
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.logoutUser
         }
-        val getPetById = getPetByIdAction { (petId: Long) =>  
+        val getPetById = getPetByIdAction { (petId: Long) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.getPetById
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.getPetById
@@ -116,7 +116,7 @@ package split.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.deletePet
         }
-        val findPetsByStatus = findPetsByStatusAction { (status: PetsFindByStatusGetStatus) =>  
+        val findPetsByStatus = findPetsByStatusAction { (status: PetsFindByStatusGetStatus) =>
             // ----- Start of unmanaged code area for action  SplitPetstoreApiYaml.findPetsByStatus
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.findPetsByStatus
@@ -127,6 +127,6 @@ package split.petstore.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  SplitPetstoreApiYaml.loginUser
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/string_formats_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/string_formats_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -43,6 +43,6 @@ package string_formats.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  String_formatsYaml.get
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/type_deduplication_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/type_deduplication_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -45,12 +45,12 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putplantsByPlant_idWateringsByWatering_id
         }
-        val getusersMe = getusersMeAction {  _ =>  
+        val getusersMe = getusersMeAction {  _ =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getusersMe
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getusersMe
         }
-        val getplantsByPlant_idSunlight_needs = getplantsByPlant_idSunlight_needsAction { (plant_id: String) =>  
+        val getplantsByPlant_idSunlight_needs = getplantsByPlant_idSunlight_needsAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idSunlight_needs
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idSunlight_needs
@@ -67,22 +67,22 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getusers
         }
-        val postusers = postusersAction { (signin_data: SigninData) =>  
+        val postusers = postusersAction { (signin_data: SigninData) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.postusers
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.postusers
         }
-        val getareasByArea_id = getareasByArea_idAction { (area_id: String) =>  
+        val getareasByArea_id = getareasByArea_idAction { (area_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getareasByArea_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getareasByArea_id
         }
-        val putareasByArea_id = putareasByArea_idAction { (area_id: String) =>  
+        val putareasByArea_id = putareasByArea_idAction { (area_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.putareasByArea_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putareasByArea_id
         }
-        val deleteareasByArea_id = deleteareasByArea_idAction { (area_id: String) =>  
+        val deleteareasByArea_id = deleteareasByArea_idAction { (area_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.deleteareasByArea_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.deleteareasByArea_id
@@ -99,7 +99,7 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getuserByUser_idPlants
         }
-        val getusersByUser_id = getusersByUser_idAction { (user_id: String) =>  
+        val getusersByUser_id = getusersByUser_idAction { (user_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getusersByUser_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getusersByUser_id
@@ -122,7 +122,7 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getareas
         }
-        val getplantsByPlant_idLocation = getplantsByPlant_idLocationAction { (plant_id: String) =>  
+        val getplantsByPlant_idLocation = getplantsByPlant_idLocationAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idLocation
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idLocation
@@ -133,22 +133,22 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putplantsByPlant_idLocation
         }
-        val deleteplantsByPlant_idLocation = deleteplantsByPlant_idLocationAction { (plant_id: String) =>  
+        val deleteplantsByPlant_idLocation = deleteplantsByPlant_idLocationAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.deleteplantsByPlant_idLocation
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.deleteplantsByPlant_idLocation
         }
-        val getusersByUser_idPicture = getusersByUser_idPictureAction { (user_id: String) =>  
+        val getusersByUser_idPicture = getusersByUser_idPictureAction { (user_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getusersByUser_idPicture
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getusersByUser_idPicture
         }
-        val putusersByUser_idPicture = putusersByUser_idPictureAction { (user_id: String) =>  
+        val putusersByUser_idPicture = putusersByUser_idPictureAction { (user_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.putusersByUser_idPicture
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putusersByUser_idPicture
         }
-        val deleteusersByUser_idPicture = deleteusersByUser_idPictureAction { (user_id: String) =>  
+        val deleteusersByUser_idPicture = deleteusersByUser_idPictureAction { (user_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.deleteusersByUser_idPicture
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.deleteusersByUser_idPicture
@@ -159,7 +159,7 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idPictures
         }
-        val getplantsByPlant_id = getplantsByPlant_idAction { (plant_id: String) =>  
+        val getplantsByPlant_id = getplantsByPlant_idAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_id
@@ -170,7 +170,7 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putplantsByPlant_id
         }
-        val deleteplantsByPlant_id = deleteplantsByPlant_idAction { (plant_id: String) =>  
+        val deleteplantsByPlant_id = deleteplantsByPlant_idAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.deleteplantsByPlant_id
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.deleteplantsByPlant_id
@@ -199,7 +199,7 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.deleteplantsByPlant_idPicturesByPicture_id
         }
-        val getplantsByPlant_idWater_needs = getplantsByPlant_idWater_needsAction { (plant_id: String) =>  
+        val getplantsByPlant_idWater_needs = getplantsByPlant_idWater_needsAction { (plant_id: String) =>
             // ----- Start of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idWater_needs
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.getplantsByPlant_idWater_needs
@@ -210,6 +210,6 @@ package type_deduplication.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Type_deduplicationYaml.putplantsByPlant_idWater_needs
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/uber_api_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/uber_api_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -33,7 +33,7 @@ package uber.api.yaml {
         // ----- Start of unmanaged code area for constructor UberApiYaml
 
         // ----- End of unmanaged code area for constructor UberApiYaml
-        val getme = getmeAction {  _ =>  
+        val getme = getmeAction {  _ =>
             // ----- Start of unmanaged code area for action  UberApiYaml.getme
             NotImplementedYet
             // ----- End of unmanaged code area for action  UberApiYaml.getme
@@ -62,6 +62,6 @@ package uber.api.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  UberApiYaml.gethistory
         }
-    
+
     }
 }

--- a/play-scala-generator/src/test/resources/expected_results/controllers/wrong_field_name_yaml.scala
+++ b/play-scala-generator/src/test/resources/expected_results/controllers/wrong_field_name_yaml.scala
@@ -1,9 +1,9 @@
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{ Action, Controller }
 
 import play.api.data.validation.Constraint
 
-import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}
+import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
 
 import de.zalando.play.controllers._
 
@@ -39,6 +39,6 @@ package wrong_field_name.yaml {
             NotImplementedYet
             // ----- End of unmanaged code area for action  Wrong_field_nameYaml.get
         }
-    
+
     }
 }


### PR DESCRIPTION
I have found that `api-first-hand` and `scalariform` can end up fighting over imports.

I run Scalariform upon every compilation with the following config
```
  ScalariformKeys.preferences := FormattingPreferences()
    .setPreference(SpacesAroundMultiImports, true)
```

Essentially, what happens seems to be that Scalariform re-formats the imports `play.api.mvc.{Action, Controller}` and `play.api.inject.{ApplicationLifecycle,ConfigurationProvider}` to include a space after the comma and the ones before inside the braces. 
Then the `api-first-hand` generator seems to determine that those imports are missing and re-adds them.

Because of this, every `sbt compile` adds a pair of imports to my generated controller.

Quickly, I ended up with an import block like this:

```
import play.api.mvc.{Action, Controller}

import play.api.data.validation.Constraint

import play.api.inject.{ApplicationLifecycle,ConfigurationProvider}

import de.zalando.play.controllers._

import PlayBodyParsing._

import PlayValidations._

import scala.util._

import javax.inject._

import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import play.api.mvc.{ Action, Controller }
import play.api.inject.{ ApplicationLifecycle, ConfigurationProvider }
import de.zalando.play.controllers.Base64String
import Base64String._
import scala.concurrent.Future
```

This change will make the generator scalariform-friendly and should resolve the above issue.
