### PR TITLE
fix parser inlude types

### DIFF
--- a/api-first-core/src/test/scala/model/resources.instagram_api_yaml.scala
+++ b/api-first-core/src/test/scala/model/resources.instagram_api_yaml.scala
@@ -7,13 +7,13 @@ import de.zalando.apifirst.Hypermedia._
 import de.zalando.apifirst.Http._
 import de.zalando.apifirst.Security
 import java.net.URL
-import Security._ 
+import Security._
 //noinspection ScalaStyle
 object instagram_api_yaml extends WithModel {
- 
+
  def types = Map[Reference, Type](
-	Reference("⌿definitions⌿User") → 
-		TypeDef(Reference("⌿definitions⌿User"), 
+	Reference("⌿definitions⌿User") →
+		TypeDef(Reference("⌿definitions⌿User"),
 			Seq(
 					Field(Reference("⌿definitions⌿User⌿website"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿User⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -21,33 +21,33 @@ object instagram_api_yaml extends WithModel {
 					Field(Reference("⌿definitions⌿User⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿User⌿bio"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿User⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿User⌿counts"), Opt(TypeDef(Reference("⌿definitions⌿User⌿counts"), 
+					Field(Reference("⌿definitions⌿User⌿counts"), Opt(TypeDef(Reference("⌿definitions⌿User⌿counts"),
 			Seq(
 						Field(Reference("⌿definitions⌿User⌿counts⌿media"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿User⌿counts⌿follows"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿User⌿counts⌿follwed_by"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 7"), List())),
-	Reference("⌿definitions⌿Image") → 
-		TypeDef(Reference("⌿definitions⌿Image"), 
+	Reference("⌿definitions⌿Image") →
+		TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 					Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())),
-	Reference("⌿definitions⌿Tag") → 
-		TypeDef(Reference("⌿definitions⌿Tag"), 
+	Reference("⌿definitions⌿Tag") →
+		TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 					Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿definitions⌿Comment") → 
-		TypeDef(Reference("⌿definitions⌿Comment"), 
+	Reference("⌿definitions⌿Comment") →
+		TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 					Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -55,10 +55,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())),
-	Reference("⌿definitions⌿Media") → 
-		TypeDef(Reference("⌿definitions⌿Media"), 
+	Reference("⌿definitions⌿Media") →
+		TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 						Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -66,15 +66,15 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿comments:"), 
+					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿comments:"),
 			Seq(
 						Field(Reference("⌿definitions⌿Media⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 							Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -83,12 +83,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 						Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -96,10 +96,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿likes"), 
+					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿likes"),
 			Seq(
 						Field(Reference("⌿definitions⌿Media⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -108,15 +108,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿videos"), 
+					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿videos"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿definitions⌿Media⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿definitions⌿Media⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -124,28 +124,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿images"), 
+					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿definitions⌿Media⌿images"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿definitions⌿Media⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿definitions⌿Media⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+						Field(Reference("⌿definitions⌿Media⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -153,8 +153,8 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())),
-	Reference("⌿definitions⌿Like") → 
-		TypeDef(Reference("⌿definitions⌿Like"), 
+	Reference("⌿definitions⌿Like") →
+		TypeDef(Reference("⌿definitions⌿Like"),
 			Seq(
 					Field(Reference("⌿definitions⌿Like⌿first_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Like⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -162,42 +162,42 @@ object instagram_api_yaml extends WithModel {
 					Field(Reference("⌿definitions⌿Like⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Like⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 5"), List())),
-	Reference("⌿definitions⌿Location") → 
-		TypeDef(Reference("⌿definitions⌿Location"), 
+	Reference("⌿definitions⌿Location") →
+		TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 					Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Location⌿latitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())),
-	Reference("⌿definitions⌿MiniProfile") → 
-		TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+	Reference("⌿definitions⌿MiniProfile") →
+		TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 					Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿MiniProfile⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())),
-	Reference("⌿parameters⌿user-id-param⌿user-id") → 
+	Reference("⌿parameters⌿user-id-param⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿parameters⌿tag-name⌿tag-name") → 
+	Reference("⌿parameters⌿tag-name⌿tag-name") →
 		Str(None, TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿count") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿count") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}⌿⌿location-id") → 
+	Reference("⌿paths⌿/locations/{location-id}⌿⌿location-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿⌿tag-name") → 
+	Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿⌿tag-name") →
 		Str(None, TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿lng") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿lng") →
 		Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{media-id}⌿⌿media-id") → 
+	Reference("⌿paths⌿/media/{media-id}⌿⌿media-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿max_id") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿max_id") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿⌿user-id") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿action") → 
-		Opt(			EnumTrait(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")""")), 
+	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿action") →
+		Opt(			EnumTrait(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")""")),
 				Set(
 					EnumObject(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), "follow", TypeMeta(Some("follow"), List())),
 					EnumObject(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), "unblock", TypeMeta(Some("unblock"), List())),
@@ -206,88 +206,88 @@ object instagram_api_yaml extends WithModel {
 					EnumObject(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), "block", TypeMeta(Some("block"), List()))
 
 				)), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/search⌿get⌿MAX_TIMESTAMP") → 
+	Reference("⌿paths⌿/media/search⌿get⌿MAX_TIMESTAMP") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/followed-by⌿⌿user-id") → 
+	Reference("⌿paths⌿/users/{user-id}/followed-by⌿⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/search⌿get⌿LAT") → 
+	Reference("⌿paths⌿/media/search⌿get⌿LAT") →
 		Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿distance") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿distance") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿facebook_places_id") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿facebook_places_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/feed⌿get⌿max_id") → 
+	Reference("⌿paths⌿/users/self/feed⌿get⌿max_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/search⌿get⌿DISTANCE") → 
+	Reference("⌿paths⌿/media/search⌿get⌿DISTANCE") →
 		BInt(TypeMeta(None, List("""max(BigInt("5000"), false)"""))),
-	Reference("⌿paths⌿/tags/{tag-name}⌿⌿tag-name") → 
+	Reference("⌿paths⌿/tags/{tag-name}⌿⌿tag-name") →
 		Str(None, TypeMeta(None, List())),
-	Reference("⌿paths⌿/tags/search⌿get⌿q") → 
+	Reference("⌿paths⌿/tags/search⌿get⌿q") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿min_id") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿min_id") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿lat") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿lat") →
 		Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿min_id") → 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿min_id") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿count") → 
+	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿count") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}⌿⌿user-id") → 
+	Reference("⌿paths⌿/users/{user-id}⌿⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/feed⌿get⌿min_id") → 
+	Reference("⌿paths⌿/users/self/feed⌿get⌿min_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿⌿location-id") → 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿⌿location-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿min_timestamp") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿min_timestamp") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/search⌿get⌿MIN_TIMESTAMP") → 
+	Reference("⌿paths⌿/media/search⌿get⌿MIN_TIMESTAMP") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/relationship⌿⌿user-id") → 
+	Reference("⌿paths⌿/users/{user-id}/relationship⌿⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿TEXT") → 
+	Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿TEXT") →
 		Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿max_id") → 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿max_id") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/search⌿get⌿LNG") → 
+	Reference("⌿paths⌿/media/search⌿get⌿LNG") →
 		Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿min_timestamp") → 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿min_timestamp") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/media/liked⌿get⌿max_like_id") → 
+	Reference("⌿paths⌿/users/self/media/liked⌿get⌿max_like_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{media-id}/comments⌿⌿media-id") → 
+	Reference("⌿paths⌿/media/{media-id}/comments⌿⌿media-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿foursquare_id") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿foursquare_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/search⌿get⌿count") → 
+	Reference("⌿paths⌿/users/search⌿get⌿count") →
 		Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/media/liked⌿get⌿count") → 
+	Reference("⌿paths⌿/users/self/media/liked⌿get⌿count") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{media-id}/likes⌿⌿media-id") → 
+	Reference("⌿paths⌿/media/{media-id}/likes⌿⌿media-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿min_id") → 
+	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿min_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿foursquare_v2_id") → 
+	Reference("⌿paths⌿/locations/search⌿get⌿foursquare_v2_id") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/follows⌿⌿user-id") → 
+	Reference("⌿paths⌿/users/{user-id}/follows⌿⌿user-id") →
 		BDcml(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/feed⌿get⌿count") → 
+	Reference("⌿paths⌿/users/self/feed⌿get⌿count") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{shortcode}⌿⌿shortcode") → 
+	Reference("⌿paths⌿/media/{shortcode}⌿⌿shortcode") →
 		Str(None, TypeMeta(None, List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿max_timestamp") → 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿max_timestamp") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿max_timestamp") → 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿max_timestamp") →
 		Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())),
-	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿⌿geo-id") → 
+	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿⌿geo-id") →
 		BInt(TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/search⌿get⌿q") → 
+	Reference("⌿paths⌿/users/search⌿get⌿q") →
 		Str(None, TypeMeta(None, List())),
-	Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"), 
+					Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 							Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -295,15 +295,15 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿comments:"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 								Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -312,12 +312,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 							Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -325,10 +325,10 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿likes"), 
+						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -337,15 +337,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos"), 
+						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -353,28 +353,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images"), 
+						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+							Field(Reference("⌿paths⌿/users/self/feed⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -383,12 +383,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"), 
+					Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 							Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -396,15 +396,15 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿comments:"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 								Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -413,12 +413,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 							Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -426,10 +426,10 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿likes"), 
+						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -438,15 +438,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos"), 
+						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -454,28 +454,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images"), 
+						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+							Field(Reference("⌿paths⌿/media/popular⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -484,19 +484,19 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿responses⌿200⌿data"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -504,23 +504,23 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+					Field(Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 						Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿meta⌿code"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿paths⌿/users/self/requested-by⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -528,19 +528,19 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿responses⌿200⌿data"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -548,10 +548,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200⌿data"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+					Field(Reference("⌿paths⌿/locations/{location-id}⌿get⌿responses⌿200⌿data"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 						Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -559,12 +559,12 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"), 
+					Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 							Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -572,15 +572,15 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 								Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -589,12 +589,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 							Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -602,10 +602,10 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes"), 
+						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -614,15 +614,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos"), 
+						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -630,28 +630,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images"), 
+						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+							Field(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -660,12 +660,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"), 
+					Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 							Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -673,15 +673,15 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿comments:"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 								Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -690,12 +690,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 							Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -703,10 +703,10 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿likes"), 
+						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -715,15 +715,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos"), 
+						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -731,28 +731,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images"), 
+						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+							Field(Reference("⌿paths⌿/users/self/media/liked⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -761,12 +761,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"), 
+					Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+						Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 							Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -774,15 +774,15 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:"), 
+						Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 								Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -791,12 +791,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+						Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 							Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -804,10 +804,10 @@ object instagram_api_yaml extends WithModel {
 							Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes"), 
+						Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -816,15 +816,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos"), 
+						Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -832,28 +832,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images"), 
+						Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+							Field(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 								Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -862,20 +862,20 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/tags/{tag-name}⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿definitions⌿Tag"), 
+	Reference("⌿paths⌿/tags/{tag-name}⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 					Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Like"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Like"),
 			Seq(
 						Field(Reference("⌿definitions⌿Like⌿first_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Like⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -884,13 +884,13 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Like⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 5"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/media/search⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/search⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200"),
 			Seq(
 					Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(				AllOf(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿data"), TypeMeta(Some("Schemas: 2"), List()),  Seq(
-				TypeDef(Reference("⌿definitions⌿Media"), 
+				TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-							Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+							Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 								Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -898,15 +898,15 @@ object instagram_api_yaml extends WithModel {
 								Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿comments:"), 
+							Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿comments:"),
 			Seq(
 								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 									Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-									Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+									Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 										Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 										Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -915,12 +915,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+							Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 								Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -928,10 +928,10 @@ object instagram_api_yaml extends WithModel {
 								Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿likes"), 
+							Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿likes"),
 			Seq(
 								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 									Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -940,15 +940,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos"), 
+							Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos"),
 			Seq(
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -956,28 +956,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images"), 
+							Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images"),
 			Seq(
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-									Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+									Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+								Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 									Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 									Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -985,28 +985,28 @@ object instagram_api_yaml extends WithModel {
 								Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())),
-				TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data"), 
+				TypeDef(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data"),
 			Seq(
 							Field(Reference("⌿paths⌿/media/search⌿get⌿responses⌿200⌿data⌿distance"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List()))) , None), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿meta⌿code"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+					Field(Reference("⌿paths⌿/tags/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 						Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿definitions⌿Media"), 
+	Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 						Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1014,15 +1014,15 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿comments:"), 
+					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿comments:"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 							Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1031,12 +1031,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 						Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1044,10 +1044,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿likes"), 
+					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿likes"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1056,15 +1056,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos"), 
+					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos"),
 			Seq(
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1072,28 +1072,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images"), 
+					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images"),
 			Seq(
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+						Field(Reference("⌿paths⌿/media/{media-id}⌿get⌿responses⌿200⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1101,10 +1101,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())),
-	Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿definitions⌿Media"), 
+	Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿definitions⌿Media"),
 			Seq(
-					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"), 
+					Field(Reference("⌿definitions⌿Media⌿location"), Opt(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 						Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1112,15 +1112,15 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿created_time"), Opt(BInt(TypeMeta(Some("Epoc time (ms)"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿comments:"), 
+					Field(Reference("⌿definitions⌿Media⌿comments:"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿comments:"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿comments:⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿comments:⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 							Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+							Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 								Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 								Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1129,12 +1129,12 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"), 
+					Field(Reference("⌿definitions⌿Media⌿tags"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Tag"),
 			Seq(
 						Field(Reference("⌿definitions⌿Tag⌿media_count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Tag⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿users_in_photo"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1142,10 +1142,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿filter"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿likes"), 
+					Field(Reference("⌿definitions⌿Media⌿likes"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿likes"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿likes⌿count"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿likes⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1154,15 +1154,15 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos"), 
+					Field(Reference("⌿definitions⌿Media⌿videos"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos"),
 			Seq(
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿videos⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1170,28 +1170,28 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿definitions⌿Media⌿type"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images"), 
+					Field(Reference("⌿definitions⌿Media⌿images"), Opt(TypeDef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images"),
 			Seq(
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
-			Seq(
-							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
-			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿low_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"), 
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿thumbnail"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
+			Seq(
+							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
+			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
+						Field(Reference("⌿paths⌿/media/{shortcode}⌿get⌿responses⌿200⌿images⌿standard_resolution"), Opt(TypeDef(Reference("⌿definitions⌿Image"),
 			Seq(
 							Field(Reference("⌿definitions⌿Image⌿width"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿height"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿Image⌿url"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿definitions⌿Media⌿user"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1199,10 +1199,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 12"), List())),
-	Reference("⌿paths⌿/users/search⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/search⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/search⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/search⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿paths⌿/users/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1210,10 +1210,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data"), Opt(TypeDef(Reference("⌿definitions⌿User"), 
+					Field(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data"), Opt(TypeDef(Reference("⌿definitions⌿User"),
 			Seq(
 						Field(Reference("⌿definitions⌿User⌿website"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿User⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1221,27 +1221,27 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿User⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿User⌿bio"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿User⌿id"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿User⌿counts"), Opt(TypeDef(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data⌿counts"), 
+						Field(Reference("⌿definitions⌿User⌿counts"), Opt(TypeDef(Reference("⌿definitions⌿User⌿counts"),
 			Seq(
-							Field(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data⌿counts⌿media"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data⌿counts⌿follows"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
-							Field(Reference("⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data⌿counts⌿follwed_by"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())))
+							Field(Reference("⌿definitions⌿User⌿counts⌿media"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿User⌿counts⌿follows"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List()))),
+							Field(Reference("⌿definitions⌿User⌿counts⌿follwed_by"), Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 3"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 7"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
-					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Comment"),
 			Seq(
 						Field(Reference("⌿definitions⌿Comment⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Comment⌿created_time"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Comment⌿text"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
-						Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+						Field(Reference("⌿definitions⌿Comment⌿from"), Opt(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 							Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 							Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1250,30 +1250,30 @@ object instagram_api_yaml extends WithModel {
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿responses⌿200") → 
+	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿responses⌿200") →
 		Null(TypeMeta(None, List())),
-	Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿responses⌿200⌿data"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200"), 
+	Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿meta"), 
+					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿meta"), Opt(TypeDef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿meta"),
 			Seq(
 						Field(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿meta⌿code"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())), TypeMeta(None, List()))),
 					Field(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿responses⌿200⌿data"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 2"), List())),
-	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200"), 
+	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"), 
+					Field(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿MiniProfile"),
 			Seq(
 						Field(Reference("⌿definitions⌿MiniProfile⌿user_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿MiniProfile⌿full_name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1281,10 +1281,10 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿MiniProfile⌿profile_picture"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List())),
-	Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200") → 
-		TypeDef(Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200"), 
+	Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200") →
+		TypeDef(Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200"),
 			Seq(
-					Field(Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Location"), 
+					Field(Reference("⌿paths⌿/locations/search⌿get⌿responses⌿200⌿data"), Opt(ArrResult(TypeDef(Reference("⌿definitions⌿Location"),
 			Seq(
 						Field(Reference("⌿definitions⌿Location⌿id"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
 						Field(Reference("⌿definitions⌿Location⌿name"), Opt(Str(None, TypeMeta(None, List())), TypeMeta(None, List()))),
@@ -1292,15 +1292,15 @@ object instagram_api_yaml extends WithModel {
 						Field(Reference("⌿definitions⌿Location⌿longitude"), Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 4"), List())), TypeMeta(None, List())), TypeMeta(None, List())))
 			), TypeMeta(Some("Named types: 1"), List()))
-) 
- 
+)
+
  def parameters = Map[ParameterRef, Parameter](
 	ParameterRef(	Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿min_timestamp")) → Parameter("min_timestamp", Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())), None, None, ".+", encode = true, ParameterPlace.withName("query")),
 	ParameterRef(	Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿media-id")) → Parameter("media-id", BInt(TypeMeta(None, List())), None, None, "[^/]+", encode = true, ParameterPlace.withName("path")),
 	ParameterRef(	Reference("⌿paths⌿/locations/{location-id}⌿get⌿location-id")) → Parameter("location-id", BInt(TypeMeta(None, List())), None, None, "[^/]+", encode = true, ParameterPlace.withName("path")),
 	ParameterRef(	Reference("⌿paths⌿/media/search⌿get⌿MAX_TIMESTAMP")) → Parameter("MAX_TIMESTAMP", Opt(BInt(TypeMeta(None, List())), TypeMeta(None, List())), None, None, ".+", encode = true, ParameterPlace.withName("query")),
 	ParameterRef(	Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿media-id")) → Parameter("media-id", BInt(TypeMeta(None, List())), None, None, "[^/]+", encode = true, ParameterPlace.withName("path")),
-	ParameterRef(	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿action")) → Parameter("action", Opt(EnumTrait(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")""")), 
+	ParameterRef(	Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿action")) → Parameter("action", Opt(EnumTrait(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")""")),
 	Set(
 		EnumObject(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), "follow", TypeMeta(Some("follow"), List())),
 		EnumObject(Str(None, TypeMeta(None, List("""enum("approve,unblock,block,unfollow,follow")"""))), "block", TypeMeta(Some("block"), List())),
@@ -1353,8 +1353,8 @@ object instagram_api_yaml extends WithModel {
 	ParameterRef(	Reference("⌿paths⌿/locations/search⌿get⌿lng")) → Parameter("lng", Opt(BDcml(TypeMeta(None, List())), TypeMeta(None, List())), None, None, ".+", encode = true, ParameterPlace.withName("query")),
 	ParameterRef(	Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿user-id")) → Parameter("user-id", BDcml(TypeMeta(None, List())), None, None, "[^/]+", encode = true, ParameterPlace.withName("path")),
 	ParameterRef(	Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿geo-id")) → Parameter("geo-id", BInt(TypeMeta(None, List())), None, None, "[^/]+", encode = true, ParameterPlace.withName("path"))
-) 
- def basePath: String = "/v1" 
+)
+ def basePath: String = "/v1"
  def discriminators: DiscriminatorLookupTable = Map[Reference, Reference](
 	)
  def securityDefinitions: SecurityDefinitionsTable = Map[String, Security.Definition](
@@ -1368,7 +1368,7 @@ def calls: Seq[ApiCall] = Seq(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaByMedia_idLikes",parameters = 
+			"getmediaByMedia_idLikes",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/likes⌿get⌿media-id"))
 				)
@@ -1387,13 +1387,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(POST, Path(Reference("⌿media⌿{media-id}⌿likes")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"postmediaByMedia_idLikes",parameters = 
+			"postmediaByMedia_idLikes",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/likes⌿post⌿media-id"))
 				)
@@ -1411,13 +1411,13 @@ def calls: Seq[ApiCall] = Seq(
 			), None),
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("comments"))
-		)), 
+		)),
 	ApiCall(DELETE, Path(Reference("⌿media⌿{media-id}⌿likes")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"deletemediaByMedia_idLikes",parameters = 
+			"deletemediaByMedia_idLikes",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/likes⌿delete⌿media-id"))
 				)
@@ -1436,13 +1436,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿{user-id}⌿follows")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersByUser_idFollows",parameters = 
+			"getusersByUser_idFollows",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/follows⌿get⌿user-id"))
 				)
@@ -1461,13 +1461,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿locations⌿{location-id}")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getlocationsByLocation_id",parameters = 
+			"getlocationsByLocation_id",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/locations/{location-id}⌿get⌿location-id"))
 				)
@@ -1486,13 +1486,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿search")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersSearch",parameters = 
+			"getusersSearch",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/search⌿get⌿q")),
 				ParameterRef(Reference("⌿paths⌿/users/search⌿get⌿count"))
@@ -1512,13 +1512,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿self⌿media⌿liked")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersSelfMediaLiked",parameters = 
+			"getusersSelfMediaLiked",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿count")),
 				ParameterRef(Reference("⌿paths⌿/users/self/media/liked⌿get⌿max_like_id"))
@@ -1538,13 +1538,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿tags⌿{tag-name}")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"gettagsByTag_name",parameters = 
+			"gettagsByTag_name",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/tags/{tag-name}⌿get⌿tag-name"))
 				)
@@ -1563,13 +1563,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿tags⌿search")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"gettagsSearch",parameters = 
+			"gettagsSearch",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/tags/search⌿get⌿q"))
 				)
@@ -1588,13 +1588,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿{user-id}⌿followed-by")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersByUser_idFollowed_by",parameters = 
+			"getusersByUser_idFollowed_by",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/followed-by⌿get⌿user-id"))
 				)
@@ -1613,13 +1613,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿media⌿{media-id}⌿comments")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaByMedia_idComments",parameters = 
+			"getmediaByMedia_idComments",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/comments⌿get⌿media-id"))
 				)
@@ -1638,13 +1638,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(POST, Path(Reference("⌿media⌿{media-id}⌿comments")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"postmediaByMedia_idComments",parameters = 
+			"postmediaByMedia_idComments",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿media-id")),
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/comments⌿post⌿TEXT"))
@@ -1663,13 +1663,13 @@ def calls: Seq[ApiCall] = Seq(
 			), None),
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("comments"))
-		)), 
+		)),
 	ApiCall(DELETE, Path(Reference("⌿media⌿{media-id}⌿comments")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"deletemediaByMedia_idComments",parameters = 
+			"deletemediaByMedia_idComments",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}/comments⌿delete⌿media-id"))
 				)
@@ -1688,13 +1688,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿tags⌿{tag-name}⌿media⌿recent")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"gettagsByTag_nameMediaRecent",parameters = 
+			"gettagsByTag_nameMediaRecent",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/tags/{tag-name}/media/recent⌿get⌿tag-name"))
 				)
@@ -1713,13 +1713,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(POST, Path(Reference("⌿users⌿{user-id}⌿relationship")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"postusersByUser_idRelationship",parameters = 
+			"postusersByUser_idRelationship",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿user-id")),
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/relationship⌿post⌿action"))
@@ -1738,13 +1738,13 @@ def calls: Seq[ApiCall] = Seq(
 			), None),
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("relationships"))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿self⌿feed")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersSelfFeed",parameters = 
+			"getusersSelfFeed",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/self/feed⌿get⌿count")),
 				ParameterRef(Reference("⌿paths⌿/users/self/feed⌿get⌿max_id")),
@@ -1765,13 +1765,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿{user-id}")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersByUser_id",parameters = 
+			"getusersByUser_id",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}⌿get⌿user-id"))
 				)
@@ -1790,13 +1790,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query"))),
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic"))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿media⌿search")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaSearch",parameters = 
+			"getmediaSearch",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/search⌿get⌿MAX_TIMESTAMP")),
 				ParameterRef(Reference("⌿paths⌿/media/search⌿get⌿DISTANCE")),
@@ -1819,13 +1819,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿geographies⌿{geo-id}⌿media⌿recent")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getgeographiesByGeo_idMediaRecent",parameters = 
+			"getgeographiesByGeo_idMediaRecent",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿geo-id")),
 				ParameterRef(Reference("⌿paths⌿/geographies/{geo-id}/media/recent⌿get⌿count")),
@@ -1846,13 +1846,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿media⌿{shortcode}")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaByShortcode",parameters = 
+			"getmediaByShortcode",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{shortcode}⌿get⌿shortcode"))
 				)
@@ -1871,13 +1871,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿locations⌿search")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getlocationsSearch",parameters = 
+			"getlocationsSearch",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/locations/search⌿get⌿foursquare_v2_id")),
 				ParameterRef(Reference("⌿paths⌿/locations/search⌿get⌿facebook_places_id")),
@@ -1901,13 +1901,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿self⌿requested-by")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersSelfRequested_by",parameters = 
+			"getusersSelfRequested_by",parameters =
 			Seq(
 
 				)
@@ -1926,13 +1926,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿media⌿{media-id}")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaByMedia_id",parameters = 
+			"getmediaByMedia_id",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/media/{media-id}⌿get⌿media-id"))
 				)
@@ -1951,13 +1951,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿locations⌿{location-id}⌿media⌿recent")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getlocationsByLocation_idMediaRecent",parameters = 
+			"getlocationsByLocation_idMediaRecent",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿location-id")),
 				ParameterRef(Reference("⌿paths⌿/locations/{location-id}/media/recent⌿get⌿max_timestamp")),
@@ -1980,13 +1980,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿users⌿{user-id}⌿media⌿recent")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getusersByUser_idMediaRecent",parameters = 
+			"getusersByUser_idMediaRecent",parameters =
 			Seq(
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿user-id")),
 				ParameterRef(Reference("⌿paths⌿/users/{user-id}/media/recent⌿get⌿max_timestamp")),
@@ -2010,13 +2010,13 @@ def calls: Seq[ApiCall] = Seq(
 		Set(
 			OAuth2Constraint("oauth", OAuth2Definition(None, Some(new URL("https://instagram.com/oauth/authorize/?client_id=CLIENT-ID&redirect_uri=REDIRECT-URI&response_type=token")), Map[String, String]( "basic" -> "to read any and all data related to a user (e.g. following/followed-by  lists, photos, etc.) (granted by default) " ,  "comments" -> "to create or delete comments on a user’s behalf" ,  "relationships" -> "to follow and unfollow users on a user’s behalf" ,  "likes" -> "to like and unlike items on a user’s behalf" )), Set("basic", "comments", "relationships", "likes")),
 			ApiKeyConstraint("key", ApiKey(None, "access_token", ParameterPlace.withName("query")))
-		)), 
+		)),
 	ApiCall(GET, Path(Reference("⌿media⌿popular")),
 		HandlerCall(
 			"instagram.api.yaml",
 			"InstagramApiYaml",
 			instantiate = false,
-			"getmediaPopular",parameters = 
+			"getmediaPopular",parameters =
 			Seq(
 
 				)
@@ -2040,5 +2040,5 @@ def calls: Seq[ApiCall] = Seq(
 def packageName: Option[String] = Some("instagram.api.yaml")
 
 def model = new StrictModel(calls, types, parameters, discriminators, basePath, packageName, stateTransitions, securityDefinitions)
-    
-} 
+
+}

--- a/swagger-parser/src/main/scala/de/zalando/swagger/typeConverter.scala
+++ b/swagger-parser/src/main/scala/de/zalando/swagger/typeConverter.scala
@@ -136,7 +136,7 @@ class TypeConverter(base: URI, model: strictModel.SwaggerModel, keyPrefix: Strin
         } getOrElse {
           val typeName = typeNameFromInlinedReference(param) getOrElse name
           val catchAll = fromSchemaOrBoolean(name / "additionalProperties", param.additionalProperties, param, isNonBodyParameter)
-          val normal = fromSchemaProperties(name, param.properties, paramRequired(param.required, param.default), isNonBodyParameter)
+          val normal = fromSchemaProperties(typeName, param.properties, paramRequired(param.required, param.default), isNonBodyParameter)
           val types = fromTypes(name, normal ++ catchAll.toSeq.flatten, typeName)
           Option(param.discriminator) foreach { d => memoizeDiscriminator(name, typeName / d) }
           checkRequired(name, required, param.default)(Seq(types))

--- a/swagger-parser/src/main/scala/de/zalando/swagger/typeConverter.scala
+++ b/swagger-parser/src/main/scala/de/zalando/swagger/typeConverter.scala
@@ -135,7 +135,7 @@ class TypeConverter(base: URI, model: strictModel.SwaggerModel, keyPrefix: Strin
           Seq(extensionType(name, everythingIsRequired, isNonBodyParameter)(p))
         } getOrElse {
           val typeName = typeNameFromInlinedReference(param) getOrElse name
-          val catchAll = fromSchemaOrBoolean(name / "additionalProperties", param.additionalProperties, param, isNonBodyParameter)
+          val catchAll = fromSchemaOrBoolean(typeName / "additionalProperties", param.additionalProperties, param, isNonBodyParameter)
           val normal = fromSchemaProperties(typeName, param.properties, paramRequired(param.required, param.default), isNonBodyParameter)
           val types = fromTypes(name, normal ++ catchAll.toSeq.flatten, typeName)
           Option(param.discriminator) foreach { d => memoizeDiscriminator(name, typeName / d) }

--- a/swagger-parser/src/test/resources/expected_results/types/instagram.api.yaml.types
+++ b/swagger-parser/src/test/resources/expected_results/types/instagram.api.yaml.types
@@ -217,9 +217,9 @@
 				Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 				Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 			Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-			Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+			Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+				Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 					Field("definitions" / "Comment" / "id", Opt(Str)), 
 					Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 					Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -237,34 +237,34 @@
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 			Field("definitions" / "Media" / "filter", Opt(Str)), 
-			Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "likes", Seq(
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+			Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+				Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 					Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 			Field("definitions" / "Media" / "id", Opt(BInt)), 
-			Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "videos", Seq(
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+				Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 			Field("definitions" / "Media" / "type", Opt(Str)), 
-			Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "images", Seq(
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+				Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/feed" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -282,9 +282,9 @@
 				Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 				Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 			Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-			Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+			Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+				Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 					Field("definitions" / "Comment" / "id", Opt(Str)), 
 					Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 					Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -302,34 +302,34 @@
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 			Field("definitions" / "Media" / "filter", Opt(Str)), 
-			Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "likes", Seq(
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+			Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+				Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 					Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 			Field("definitions" / "Media" / "id", Opt(BInt)), 
-			Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "videos", Seq(
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+				Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 			Field("definitions" / "Media" / "type", Opt(Str)), 
-			Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "images", Seq(
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+				Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/media/popular" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -392,9 +392,9 @@
 				Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 				Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 			Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-			Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+			Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+				Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 					Field("definitions" / "Comment" / "id", Opt(Str)), 
 					Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 					Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -412,34 +412,34 @@
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 			Field("definitions" / "Media" / "filter", Opt(Str)), 
-			Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes", Seq(
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+			Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+				Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 					Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 			Field("definitions" / "Media" / "id", Opt(BInt)), 
-			Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos", Seq(
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+				Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 			Field("definitions" / "Media" / "type", Opt(Str)), 
-			Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "images", Seq(
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+				Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/{user-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -457,9 +457,9 @@
 				Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 				Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 			Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-			Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+			Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+				Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 					Field("definitions" / "Comment" / "id", Opt(Str)), 
 					Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 					Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -477,34 +477,34 @@
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 			Field("definitions" / "Media" / "filter", Opt(Str)), 
-			Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "likes", Seq(
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+			Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+				Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 					Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 			Field("definitions" / "Media" / "id", Opt(BInt)), 
-			Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "videos", Seq(
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+				Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 			Field("definitions" / "Media" / "type", Opt(Str)), 
-			Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "images", Seq(
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+				Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/users/self/media/liked" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -522,9 +522,9 @@
 				Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 				Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 			Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-			Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+			Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+				Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 					Field("definitions" / "Comment" / "id", Opt(Str)), 
 					Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 					Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -542,34 +542,34 @@
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 			Field("definitions" / "Media" / "filter", Opt(Str)), 
-			Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes", Seq(
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+			Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+				Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+				Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 					Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 			Field("definitions" / "Media" / "id", Opt(BInt)), 
-			Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos", Seq(
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+				Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 			Field("definitions" / "Media" / "type", Opt(Str)), 
-			Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "images", Seq(
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+				Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))), 
-				Field("paths" / "/locations/{location-id}/media/recent" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 					Field("definitions" / "Image" / "width", Opt(BInt)), 
 					Field("definitions" / "Image" / "height", Opt(BInt)), 
 					Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -602,9 +602,9 @@
 					Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 					Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 				Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-				Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "comments:", Seq(
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "comments:" / "count", Opt(BInt)), 
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+				Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+					Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+					Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 						Field("definitions" / "Comment" / "id", Opt(Str)), 
 						Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 						Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -622,34 +622,34 @@
 					Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 					Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 				Field("definitions" / "Media" / "filter", Opt(Str)), 
-				Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "likes", Seq(
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "likes" / "count", Opt(BInt)), 
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+				Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+					Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+					Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 						Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 						Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 						Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 						Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 				Field("definitions" / "Media" / "id", Opt(BInt)), 
-				Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "videos", Seq(
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+					Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 						Field("definitions" / "Image" / "width", Opt(BInt)), 
 						Field("definitions" / "Image" / "height", Opt(BInt)), 
 						Field("definitions" / "Image" / "url", Opt(Str)))))), 
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+					Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 						Field("definitions" / "Image" / "width", Opt(BInt)), 
 						Field("definitions" / "Image" / "height", Opt(BInt)), 
 						Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 				Field("definitions" / "Media" / "type", Opt(Str)), 
-				Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "images", Seq(
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+				Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+					Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 						Field("definitions" / "Image" / "width", Opt(BInt)), 
 						Field("definitions" / "Image" / "height", Opt(BInt)), 
 						Field("definitions" / "Image" / "url", Opt(Str)))))), 
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+					Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 						Field("definitions" / "Image" / "width", Opt(BInt)), 
 						Field("definitions" / "Image" / "height", Opt(BInt)), 
 						Field("definitions" / "Image" / "url", Opt(Str)))))), 
-					Field("paths" / "/media/search" / "get" / "responses" / "200" / "data" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+					Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 						Field("definitions" / "Image" / "width", Opt(BInt)), 
 						Field("definitions" / "Image" / "height", Opt(BInt)), 
 						Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -675,9 +675,9 @@
 			Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 			Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 		Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-		Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "comments:", Seq(
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "comments:" / "count", Opt(BInt)), 
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+		Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+			Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+			Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 				Field("definitions" / "Comment" / "id", Opt(Str)), 
 				Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 				Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -695,34 +695,34 @@
 			Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 			Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 		Field("definitions" / "Media" / "filter", Opt(Str)), 
-		Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "likes", Seq(
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "likes" / "count", Opt(BInt)), 
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+		Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+			Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+			Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 				Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 				Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 		Field("definitions" / "Media" / "id", Opt(BInt)), 
-		Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "videos", Seq(
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+		Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+			Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 		Field("definitions" / "Media" / "type", Opt(Str)), 
-		Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "images", Seq(
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+		Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+			Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{media-id}" / "get" / "responses" / "200" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -739,9 +739,9 @@
 			Field("definitions" / "Location" / "latitude", Opt(BDcml)), 
 			Field("definitions" / "Location" / "longitude", Opt(BDcml)))))), 
 		Field("definitions" / "Media" / "created_time", Opt(BInt)), 
-		Field("definitions" / "Media" / "comments:", Opt(TypeDef("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "comments:", Seq(
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "comments:" / "count", Opt(BInt)), 
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
+		Field("definitions" / "Media" / "comments:", Opt(TypeDef("definitions" / "Media" / "comments:", Seq(
+			Field("definitions" / "Media" / "comments:" / "count", Opt(BInt)), 
+			Field("definitions" / "Media" / "comments:" / "data", Opt(ArrResult(TypeDef("definitions" / "Comment", Seq(
 				Field("definitions" / "Comment" / "id", Opt(Str)), 
 				Field("definitions" / "Comment" / "created_time", Opt(Str)), 
 				Field("definitions" / "Comment" / "text", Opt(Str)), 
@@ -759,34 +759,34 @@
 			Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 			Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))), 
 		Field("definitions" / "Media" / "filter", Opt(Str)), 
-		Field("definitions" / "Media" / "likes", Opt(TypeDef("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "likes", Seq(
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "likes" / "count", Opt(BInt)), 
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
+		Field("definitions" / "Media" / "likes", Opt(TypeDef("definitions" / "Media" / "likes", Seq(
+			Field("definitions" / "Media" / "likes" / "count", Opt(BInt)), 
+			Field("definitions" / "Media" / "likes" / "data", Opt(ArrResult(TypeDef("definitions" / "MiniProfile", Seq(
 				Field("definitions" / "MiniProfile" / "user_name", Opt(Str)), 
 				Field("definitions" / "MiniProfile" / "full_name", Opt(Str)), 
 				Field("definitions" / "MiniProfile" / "id", Opt(BInt)), 
 				Field("definitions" / "MiniProfile" / "profile_picture", Opt(Str))))))))))), 
 		Field("definitions" / "Media" / "id", Opt(BInt)), 
-		Field("definitions" / "Media" / "videos", Opt(TypeDef("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "videos", Seq(
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+		Field("definitions" / "Media" / "videos", Opt(TypeDef("definitions" / "Media" / "videos", Seq(
+			Field("definitions" / "Media" / "videos" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "videos" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
 		Field("definitions" / "Media" / "type", Opt(Str)), 
-		Field("definitions" / "Media" / "images", Opt(TypeDef("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "images", Seq(
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+		Field("definitions" / "Media" / "images", Opt(TypeDef("definitions" / "Media" / "images", Seq(
+			Field("definitions" / "Media" / "images" / "low_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images" / "thumbnail", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))), 
-			Field("paths" / "/media/{shortcode}" / "get" / "responses" / "200" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
+			Field("definitions" / "Media" / "images" / "standard_resolution", Opt(TypeDef("definitions" / "Image", Seq(
 				Field("definitions" / "Image" / "width", Opt(BInt)), 
 				Field("definitions" / "Image" / "height", Opt(BInt)), 
 				Field("definitions" / "Image" / "url", Opt(Str)))))))))), 
@@ -811,10 +811,10 @@
 			Field("definitions" / "User" / "full_name", Opt(Str)), 
 			Field("definitions" / "User" / "bio", Opt(Str)), 
 			Field("definitions" / "User" / "id", Opt(BInt)), 
-			Field("definitions" / "User" / "counts", Opt(TypeDef("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts", Seq(
-				Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "media", Opt(BInt)), 
-				Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "follows", Opt(BInt)), 
-				Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "follwed_by", Opt(BInt))))))))))))
+			Field("definitions" / "User" / "counts", Opt(TypeDef("definitions" / "User" / "counts", Seq(
+				Field("definitions" / "User" / "counts" / "media", Opt(BInt)), 
+				Field("definitions" / "User" / "counts" / "follows", Opt(BInt)), 
+				Field("definitions" / "User" / "counts" / "follwed_by", Opt(BInt))))))))))))
 "paths" / "/media/{media-id}/comments" / "get" / "responses" / "200" ->
 	TypeDef("paths" / "/media/{media-id}/comments" / "get" / "responses" / "200", Seq(
 		Field("paths" / "/media/{media-id}/comments" / "get" / "responses" / "200" / "meta", Opt(TypeDef("paths" / "/media/{media-id}/comments" / "get" / "responses" / "200" / "meta", Seq(


### PR DESCRIPTION
Reasoning:

When parser creates the model it creates invalid references e.g.:
```
Field("definitions" / "User" / "counts", Opt(TypeDef("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts", Seq(
    Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "media", Opt(BInt)), 
    Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "follows", Opt(BInt)), 
    Field("paths" / "/users/{user-id}" / "get" / "responses" / "200" / "data" / "counts" / "follwed_by", Opt(BInt))))))))))))
```
https://github.com/zalando/api-first-hand/blob/master/swagger-parser/src/test/resources/expected_results/types/instagram.api.yaml.types#L814

As one can see field with reference `⌿definitions⌿User⌿counts` refers typedef with reference `⌿paths⌿/users/{user-id}⌿get⌿responses⌿200⌿data⌿counts` which is incorrect.

This happens only with objects inside other objects because function `fromTypes` replaces name for all fields on the first level of an object.

The actual issue is that the next step - flattener might extract type with wrong type reference. This will cause modelConverter to fail while resolving type using not existent reference.

Currently type flattener tests don't fail because during flattening of instagram api example flattener imports right `⌿definitions⌿User` mapping after the incorrect one during the same iteration on https://github.com/zalando/api-first-hand/blob/master/api-first-core/src/main/scala/de/zalando/apifirst/TypeFlattener.scala#L127

But it might be a case if `typeDefs ` map will have different ordering.

This pr fixes initial issue in the parser.